### PR TITLE
split_to_elements: avoid gregexec for R 4.0 compatibility

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -108,6 +108,55 @@ trigger:
 ---
 kind: pipeline
 type: docker
+name: mpn-latest-r40
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+- name: pull
+  image: omerxx/drone-ecr-auth
+  commands:
+  - $(aws ecr get-login --no-include-email --region us-east-1)
+  - docker pull 906087756158.dkr.ecr.us-east-1.amazonaws.com/r-dev-ci-mpn-4.0:latest
+  volumes:
+  - name: docker.sock
+    path: /var/run/docker.sock
+
+- name: check
+  pull: never
+  image: 906087756158.dkr.ecr.us-east-1.amazonaws.com/r-dev-ci-mpn-4.0:latest
+  commands:
+  - make check
+  volumes:
+  - name: cache
+    path: /ephemeral
+
+- name: check_pkgdown
+  pull: never
+  image: 906087756158.dkr.ecr.us-east-1.amazonaws.com/r-dev-ci-mpn-4.0:latest
+  commands:
+  - make check-pkgdown
+  volumes:
+  - name: cache
+    path: /ephemeral
+
+volumes:
+- name: docker.sock
+  host:
+    path: /var/run/docker.sock
+- name: cache
+  temp: {}
+
+trigger:
+  event:
+    exclude:
+    - promote
+
+---
+kind: pipeline
+type: docker
 name: release
 
 platform:

--- a/R/elem.R
+++ b/R/elem.R
@@ -10,11 +10,10 @@
 #'   `nmrec_element` subclass.
 #' @noRd
 split_to_elements <- function(lines) {
-  matches <- gregexec("[ \t]+|[,;=&()'\"]", lines)
-  ln_delim_idxs <- purrr::map(matches, as.vector)
+  ln_delim_idxs <- gregexpr("[ \t]+|[,;=&()'\"]", lines)
   ln_offsets <- purrr::map(
-    matches,
-    function(x) as.vector(attr(x, "match.length")) - 1
+    ln_delim_idxs,
+    function(x) attr(x, "match.length") - 1
   )
 
   n_lines <- length(lines)


### PR DESCRIPTION
split_to_elements() uses gregexec(), but that isn't available until R 4.1.  nmrec is intended for use in packages on MPN (most notably bbr), and MPN targets R 4.0 and R 4.1, so declaring R 4.1 as the minimum R version isn't an option.

However, this spot doesn't need gregexec() because split_to_elements() doesn't use a pattern with subexpressions.  gregexpr(), which is available since R 2.10.0, is the more appropriate grep.R function.

Thanks to @barrettk for reporting.