### PR TITLE
record_names: add $THTA alias

### DIFF
--- a/R/record-names.R
+++ b/R/record-names.R
@@ -210,6 +210,7 @@ record_names <- list2env(
     "tab" = "table",
     "tabl" = "table",
     "table" = "table",
+    "thta" = "theta",
     "the" = "theta",
     "thet" = "theta",
     "theta" = "theta",


### PR DESCRIPTION
The NM-TRAN guide documents $THTA as an alias for $THETA.  Add the alias to the record_names environment, which stores a map of all name variants for a record to the full record name.