### PR TITLE
DESCRIPTION: drop "library" from description field

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,8 +10,9 @@ Authors@R:
              family = "Barrett",
              role = "aut",
              email = "barrettk@metrumrg.com"))
-Description: A library for reading records from a NONMEM control stream,
-    parsing and modifying records of interest, and writing the result.
+Description: An interface reading records from a NONMEM control
+    stream, parsing and modifying records of interest, and writing the
+    result.
 License: MIT + file LICENSE
 Encoding: UTF-8
 URL: https://metrumresearchgroup.github.io/nmrec, https://github.com/metrumresearchgroup/nmrec

--- a/man/nmrec-package.Rd
+++ b/man/nmrec-package.Rd
@@ -8,7 +8,7 @@
 \description{
 \if{html}{\figure{logo.png}{options: style='float: right' alt='logo' width='120'}}
 
-A library for reading records from a NONMEM control stream, parsing and modifying records of interest, and writing the result.
+An interface reading records from a NONMEM control stream, parsing and modifying records of interest, and writing the result.
 }
 \seealso{
 Useful links:


### PR DESCRIPTION
Avoid "library" given that R reserves that term for a "place that R knows to find packages" (doc/manual/R-FAQ.texi).