### PR TITLE
parse_ctl: abort if input contains newline

### DIFF
--- a/R/read-ctl.R
+++ b/R/read-ctl.R
@@ -45,6 +45,10 @@ parse_ctl <- function(lines) {
     )
   }
 
+  if (any(grepl("\n", lines, fixed = TRUE))) {
+    abort("parse_ctl() input must be split on newlines.", nmrec_error())
+  }
+
   # ATTN: Hold off on vectorizing or otherwise optimizing until implementation
   # settles along with tests.
   beg_pos <- grep("^[ \t]*\\$[A-Za-z]", lines)

--- a/tests/testthat/test-read-ctl.R
+++ b/tests/testthat/test-read-ctl.R
@@ -18,6 +18,20 @@ test_that("read_ctl() aborts if no records are found", {
   expect_error(read_ctl(empty_file), class = "nmrec_parse_error")
 })
 
+test_that("parse_ctl() aborts if input contains newlines", {
+  cases <- list(
+    "\n",
+    "$problem prob\n$theta\n1",
+    c("$problem prob", "\n"),
+    c("$problem prob", "$theta\n1")
+  )
+  for (case in cases) {
+    expect_error(parse_ctl(!!case), "must be split",
+      class = "nmrec_error"
+    )
+  }
+})
+
 test_that("parse_ctl() warns on unknown record", {
   cases <- list(
     c("$PROBLEM", "$FOO"),


### PR DESCRIPTION
parse_ctl() accepts _lines_ of the control stream as input.  If a caller instead passes the content of the control stream as a single string and there are no newline characters before the problem record, everything downstream is parsed as part of the problem record.  (If the first line isn't a problem record, parse_ctl() aborts saying that no records were found.)

Abort if any input line contains a newline character to make it clearer that the input is invalid.

Re: https://github.com/metrumresearchgroup/nmrec/issues/13#issuecomment-1749436883