### PR TITLE
select_records: don't fail on string records

### DIFF
--- a/R/select-records.R
+++ b/R/select-records.R
@@ -21,5 +21,7 @@ select_records <- function(records, name) {
   stopifnot(length(name) == 1, is.character(name), nzchar(name))
 
   name_resolved <- resolve_record_name(name)
-  purrr::keep(records$records, function(x) identical(x[["name"]], name_resolved))
+  purrr::keep(records$records, function(x) {
+    inherits(x, "nmrec_record") && identical(x[["name"]], name_resolved)
+  })
 }

--- a/tests/testthat/test-modify.R
+++ b/tests/testthat/test-modify.R
@@ -48,3 +48,9 @@ test_that("can modify control stream", {
     "$prob foo\n$est METHOD bayes niter=200\nprint=1\n"
   )
 })
+
+test_that("can insert string for a record", {
+  ctl <- parse_ctl(c("$prob p", "$theta 1", "$omega 2"))
+  ctl$records[[2]] <- "$theta 3\n"
+  expect_identical(format(ctl), "$prob p\n$theta 3\n$omega 2\n")
+})

--- a/tests/testthat/test-select-records.R
+++ b/tests/testthat/test-select-records.R
@@ -11,3 +11,10 @@ test_that("select_records() works", {
   expect_length(thetas, 1)
   expect_s3_class(thetas[[1]], "nmrec_record_theta")
 })
+
+test_that("select_records() skips strings", {
+  ctl <- parse_ctl(c("$prob p", "$theta 1", "$omega 2"))
+  ctl$records[[2]] <- "$theta 3\n"
+  thetas <- select_records(ctl, "theta")
+  expect_identical(thetas, list())
+})


### PR DESCRIPTION
The user may insert string into the `$records` list.  Prevent `select_records()` from failing in this case.