### PR TITLE
Prepare for 0.3.0 release

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -223,4 +223,6 @@ trigger:
   - tag
 
 depends_on:
+- cran-latest
 - mpn-latest
+- mpn-latest-r40

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: nmrec
 Title: Read, Parse, and Modify NONMEM Control Records
-Version: 0.2.0.8000
+Version: 0.3.0
 Authors@R:
     c(person(given = "Kyle",
              family = "Meyer",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,31 @@
+# nmrec 0.3.0
+
+## New features and changes
+
+* New functions `set_theta()`, `set_omega()`, and `set_sigma()`
+  provide an interface for setting the initial estimates of `$THETA`,
+  `$OMEGA`, and `$SIGMA` records.  (#18)
+
+* The `VALUES(diag,odiag)` option in `$OMEGA` and `$SIGMA` records
+  used to be parsed into an option with the value "(diag,odiag)".  It
+  is now parsed into a nested option that includes `diag` and `odiag`
+  options, enabling `diag` and `odiag` to be more easily accessed and
+  set.  (#18)
+
+* `parse_ctl()` now checks whether any of the input lines have newline
+  characters (which is invalid) and aborts.  (#21)
+
+## Bug fixes
+
+* `$THTA` was not recognized as an alias for `$THETA`.  (#17)
+
+* For the `$THETA` form "(low,,up)", the parser returned an option
+  with `up` as the `init` value.  (#18)
+
+* Users may insert a string for a record in the `records` list of
+  `nmrec_ctl_records` objects, but `select_records()` crashed on
+  string values.  It now skips strings.  (#22)
+
 # nmrec 0.2.0
 
 ## New features


### PR DESCRIPTION
changeset: https://github.com/metrumresearchgroup/nmrec/compare/0.2.0...release/0.3.0

<details>
<summary>mpn.scorecard scores</summary>

```json
{
  "testing": {
    "check": 1,
    "covr": 0.9867
  },
  "documentation": {
    "has_vignettes": 1,
    "has_website": 1,
    "has_news": 1
  },
  "maintenance": {
    "has_maintainer": 1,
    "news_current": 1
  },
  "transparency": {
    "has_source_control": 1,
    "has_bug_reports_url": 1
  }
}
```

</details>
