### PR TITLE
param docs: don't describe record names for priors as "informative"

### DIFF
--- a/R/extract-param.R
+++ b/R/extract-param.R
@@ -20,8 +20,8 @@
 #'    example, a record of `$THETA (1)x4` is returned as `c(1, NA, NA, NA)`.
 #'
 #'  * If additional parameter records are used for priors, those are included in
-#'    the result. To avoid this, instead use informative prior record names
-#'    (such as `THETAP` and `THETAPV`).
+#'    the result. To avoid this, instead use more specific record names (such as
+#'    `THETAP` and `THETAPV`).
 #'
 #' @param records An [nmrec_ctl_records] object.
 #' @param mark_flags A vector of NONMEM flags (i.e. valueless options such as

--- a/R/set-param.R
+++ b/R/set-param.R
@@ -19,7 +19,7 @@
 #'
 #'  * Using additional parameter records for priors is not supported and will
 #'    lead to a size mismatch between the parameter and its records. Instead use
-#'    informative prior record names (such as `THETAP` and `THETAPV`).
+#'    more specific record names (such as `THETAP` and `THETAPV`).
 #'
 #' @param records An [nmrec_ctl_records] object.
 #' @param values Overwrite the parameter's initial estimates in `records` with
@@ -195,7 +195,7 @@ set_param <- function(records, name, values, fmt) {
         ),
         "i" = paste0(
           "If you're using ", toupper(name), " records for priors, ",
-          "please switch to informative record names ",
+          "please switch to more specific record names ",
           "(such as THETAP and THETAPV)."
         )
       ),

--- a/man/extract_param.Rd
+++ b/man/extract_param.Rd
@@ -60,8 +60,8 @@ estimates for \code{OMEGA} and \code{SIGMA} records.
 defined in the control stream. All other values are returned as \code{NA}. For
 example, a record of \verb{$THETA (1)x4} is returned as \code{c(1, NA, NA, NA)}.
 \item If additional parameter records are used for priors, those are included in
-the result. To avoid this, instead use informative prior record names
-(such as \code{THETAP} and \code{THETAPV}).
+the result. To avoid this, instead use more specific record names (such as
+\code{THETAP} and \code{THETAPV}).
 }
 }
 }

--- a/man/set_param.Rd
+++ b/man/set_param.Rd
@@ -72,7 +72,7 @@ initial estimates, but only the first explicitly appears. Calling
 by the parameter records.
 \item Using additional parameter records for priors is not supported and will
 lead to a size mismatch between the parameter and its records. Instead use
-informative prior record names (such as \code{THETAP} and \code{THETAPV}).
+more specific record names (such as \code{THETAP} and \code{THETAPV}).
 }
 }
 }


### PR DESCRIPTION
The set-param and extract-param docs call records like THETAP and THETAPV as "informative prior record names" because NONMEM refers to records like THETAP and THETAPV as "informative record names". However, that invites confusion with the unrelated statistical concept of informative/non-informative priors (even more so because the nmrec docs unnecessarily insert "prior" between "informative" and "record names").

Drop "informative" entirely to avoid confusion.  While at it, reduce "prior record names" to "record names" because "prior" makes it harder to parse and is unnecessary given the context.

Thanks to @timwaterhouse for the suggestion.

Re: https://github.com/metrumresearchgroup/bbr/pull/635#issuecomment-1917912006