### PR TITLE
ci: add workflow to deploy pkgdown site

### DIFF
--- a/.github/workflows/site.yaml
+++ b/.github/workflows/site.yaml
@@ -1,0 +1,30 @@
+name: Deploy site
+on:
+  push:
+    branches:
+      - scratch/deploy-site
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Fetch tags for more informative git-describe output.
+          fetch-depth: 0
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: release
+          use-public-rspm: true
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::pkgdown
+      - name: Build site
+        run: pkgdown::build_site_github_pages(dest_dir = "docs", install = TRUE)
+        shell: Rscript {0}
+      - uses: metrumresearchgroup/actions/subdir-to-gh-pages@v1


### PR DESCRIPTION
Add a workflow to deploy <https://metrumresearchgroup.github.io/nmrec/> on tag push (or alternatively with push to `scratch/deploy-site` or manual trigger).

---

Run for a `scratch/deploy-site` push: https://github.com/metrumresearchgroup/nmrec/actions/runs/13313275581