### PR TITLE
tests: add matrix test case for NAMES

### DIFF
--- a/tests/testthat/test-record-omega.R
+++ b/tests/testthat/test-record-omega.R
@@ -283,6 +283,35 @@ test_that("parse_omega_record() works", {
       )
     ),
     list(
+      input = "$OMEGA BLOCK(4) NAMES  (ECL, EV1, EQ,EV2) VALUES (0.1,0.01)",
+      want = list(
+        values = list(
+          option_record_name$new("omega", "OMEGA"),
+          elem_whitespace(" "),
+          option_value$new("block", "BLOCK", "(4)", sep = ""),
+          elem_whitespace(" "),
+          option_value$new(
+            "names",
+            name_raw = "NAMES", value = "(ECL, EV1, EQ,EV2)", sep = "  "
+          ),
+          elem_whitespace(" "),
+          option_nested$new(
+            "omega",
+            values = list(
+              option_flag$new("values", "VALUES"),
+              elem_whitespace(" "),
+              elem_paren_open(),
+              option_pos$new("diag", "0.1"),
+              elem_comma(),
+              option_pos$new("odiag", "0.01"),
+              elem_paren_close()
+            )
+          ),
+          elem_linebreak()
+        )
+      )
+    ),
+    list(
       input = c(
         "$OMEGA BLOCK(4)",
         "ECL=  0.1",


### PR DESCRIPTION
$OMEGA and $SIGMA records can specify labels via NAMES:

    BLOCK(n) NAMES (label1,...,labeln) VALUES (diag,odiag)

Add a test case to confirm that this form is covered by the parse_matrix_record helper that's used for $OMEGA and $SIGMA records.

(NAMES is tested for $THETA records, but that has distinct handling.)