### PR TITLE
matrix parser: support SCALE option (NM 7.6)

### DIFF
--- a/R/extract-param.R
+++ b/R/extract-param.R
@@ -126,6 +126,15 @@ extract_matrix <- function(name, records, mark_flags) {
   size <- pinfo[["size"]]
   lsize <- matrix_ltri_size(size)
 
+  for (rec in pinfo[["records"]]) {
+    if (matrix_has_scale_option(rec)) {
+      warning(
+        "SCALE option should be accounted for when working with raw values:\n",
+        rec$format()
+      )
+    }
+  }
+
   res <- param_fill(
     rep(NA_real_, lsize),
     function(key) param_get_init(pinfo, key)

--- a/R/parse-matrix.R
+++ b/R/parse-matrix.R
@@ -20,15 +20,18 @@ parse_matrix_block <- function(name, rp) {
   rp$walk(function(r) {
     process_matrix_options(r, fail_on_unknown = FALSE)
     param_parse_label(r)
-    process_matrix_options(r, fail_on_unknown = FALSE)
-    if (!rp$done() && startsWith("values", tolower(rp$current()))) {
-      parse_matrix_block_vpair(name, r)
-      process_matrix_options(r, fail_on_unknown = FALSE)
-    } else if (!r$done()) {
+  })
+  if (!rp$done() && startsWith("values", tolower(rp$current()))) {
+    parse_matrix_block_vpair(name, rp)
+    process_matrix_options(rp, fail_on_unknown = FALSE)
+  } else if (!rp$done()) {
+    rp$walk(function(r) {
       parse_matrix_block_init(name, r)
       process_matrix_options(r, fail_on_unknown = FALSE)
-    }
-  })
+      param_parse_label(r)
+      process_matrix_options(r, fail_on_unknown = FALSE)
+    })
+  }
 }
 
 parse_matrix_block_init <- function(name, rp) {

--- a/R/parse-matrix.R
+++ b/R/parse-matrix.R
@@ -10,7 +10,7 @@ parse_matrix_record <- function(name, rp) {
   rp$gobble()
 
   fn <- if (is_block) parse_matrix_block else parse_matrix_diag
-  rp$walk(purrr::partial(fn, name = name))
+  fn(name, rp)
   rp$assert_done()
 
   return(rp$get_values())

--- a/R/record-matrix.R
+++ b/R/record-matrix.R
@@ -66,3 +66,9 @@ matrix_option_names <- list2env(
   ),
   parent = diag_option_names
 )
+
+matrix_has_scale_option <- function(record) {
+  purrr::some(record[["values"]], function(v) {
+    inherits(v, "nmrec_option_value") && identical(v[["name"]], "scale")
+  })
+}

--- a/R/set-param.R
+++ b/R/set-param.R
@@ -148,6 +148,14 @@ set_matrix <- function(name, records, values, fmt, representation) {
     modified_popts <- res[["modified_popts"]]
     ridxs <- unique(modified_records[modified_records != 0])
     for (ridx in ridxs) {
+      rec <- pinfo[["records"]][[ridx]]
+      if (matrix_has_scale_option(rec)) {
+        warning(
+          "Result may be unexpected because record has SCALE option:\n",
+          rec$format()
+        )
+      }
+
       if (identical(details[[ridx]][["type"]], "diagonal")) {
         # For diagonal, options like SD are attached to individual estimates.
         popts <- details[[ridx]][["popts"]]
@@ -155,7 +163,7 @@ set_matrix <- function(name, records, values, fmt, representation) {
         purrr::walk(popts[oidxs], matrix_reset_var_covar)
       } else {
         # For block, options like SD apply to all values.
-        matrix_reset_var_covar(pinfo[["records"]][[ridx]])
+        matrix_reset_var_covar(rec)
       }
     }
   }

--- a/tests/testthat/test-extract-param.R
+++ b/tests/testthat/test-extract-param.R
@@ -529,3 +529,54 @@ test_that("extract_sigma() works", {
   )
   expect_identical(got, want)
 })
+
+test_that("extract_omega() warns about SCALE", {
+  cases <- list(
+    list(
+      lines = "$omega 0.5 scale(2.0) 0.8 0.9 sca(1.5) 0.1",
+      want = structure(
+        matrix(
+          c(
+            0.5, NA_real_, NA_real_, NA_real_,
+            NA_real_, 0.8, NA_real_, NA_real_,
+            NA_real_, NA_real_, 0.9, NA_real_,
+            NA_real_, NA_real_, NA_real_, 0.1
+          ),
+          nrow = 4, ncol = 4, byrow = TRUE
+        ),
+        nmrec_record_size = 4L
+      )
+    ),
+    list(
+      lines = c(
+        "$omega scale(3) block (2)",
+        "0.1",
+        "0.01 0.2",
+        "$omega block(2) same"
+      ),
+      want = structure(
+        matrix(
+          c(
+            0.1, NA_real_, NA_real_, NA_real_,
+            0.01, 0.2, NA_real_, NA_real_,
+            NA_real_, NA_real_, NA_real_, NA_real_,
+            NA_real_, NA_real_, NA_real_, NA_real_
+          ),
+          nrow = 4, ncol = 4, byrow = TRUE
+        ),
+        nmrec_record_size = c(2L, 2L)
+      )
+    )
+  )
+  for (case in cases) {
+    ctl <- parse_ctl(c(prob_line, case$lines))
+    want <- case$want
+    expect_warning(
+      expect_identical(
+        extract_omega(ctl),
+        case$want
+      ),
+      "SCALE"
+    )
+  }
+})

--- a/tests/testthat/test-param-index.R
+++ b/tests/testthat/test-param-index.R
@@ -559,6 +559,65 @@ test_that("create_param_index() works: matrix", {
           )
         )
       )
+    ),
+    list(
+      lines = c(
+        "$OMEGA SCALE(1.5) BLOCK(2)",
+        "1",
+        "2 SCALE(2.5) 3"
+      ),
+      want = list(
+        details = list(
+          list(
+            type = "block",
+            subtype = "plain",
+            size = 2L
+          )
+        ),
+        size = 2L,
+        ltri_to_opt = list(
+          p1 = list(
+            opt = option_pos$new("init", "1"),
+            popt_index = 1L,
+            record_index = 1L
+          ),
+          p2 = list(
+            opt = option_pos$new("init", "2"),
+            popt_index = 2L,
+            record_index = 1L
+          ),
+          p3 = list(
+            opt = option_pos$new("init", "3"),
+            popt_index = 3L,
+            record_index = 1L
+          )
+        )
+      )
+    ),
+    list(
+      lines = "$OMEGA (1)x2 SCALE (0.5) 3",
+      want = list(
+        details = list(
+          list(
+            type = "diagonal",
+            subtype = "implicit",
+            size = 3L
+          )
+        ),
+        size = 3L,
+        ltri_to_opt = list(
+          p1 = list(
+            opt = option_pos$new("init", "1"),
+            popt_index = 1L,
+            record_index = 1L
+          ),
+          p6 = list(
+            opt = option_pos$new("init", "3"),
+            popt_index = 2L,
+            record_index = 1L
+          )
+        )
+      )
     )
   )
 

--- a/tests/testthat/test-record-omega.R
+++ b/tests/testthat/test-record-omega.R
@@ -439,6 +439,411 @@ test_that("parse_omega_record() works", {
           elem_linebreak()
         )
       )
+    ),
+    list(
+      input = "$OMEGA 0.5 0.7 SCALE(2.0) 0.8 0.9 sca(1.5) 0.1 0.2",
+      want = list(
+        values = list(
+          option_record_name$new("omega", "OMEGA"),
+          elem_whitespace(" "),
+          option_nested$new(
+            "omega",
+            values = list(option_pos$new("init", "0.5"))
+          ),
+          elem_whitespace(" "),
+          option_nested$new(
+            "omega",
+            values = list(option_pos$new("init", "0.7"))
+          ),
+          elem_whitespace(" "),
+          option_value$new("scale", "SCALE", "(2.0)", sep = ""),
+          elem_whitespace(" "),
+          option_nested$new(
+            "omega",
+            values = list(option_pos$new("init", "0.8"))
+          ),
+          elem_whitespace(" "),
+          option_nested$new(
+            "omega",
+            values = list(option_pos$new("init", "0.9"))
+          ),
+          elem_whitespace(" "),
+          option_value$new("scale", "sca", "(1.5)", sep = ""),
+          elem_whitespace(" "),
+          option_nested$new(
+            "omega",
+            values = list(option_pos$new("init", "0.1"))
+          ),
+          elem_whitespace(" "),
+          option_nested$new(
+            "omega",
+            values = list(option_pos$new("init", "0.2"))
+          ),
+          elem_linebreak()
+        )
+      )
+    ),
+    list(
+      input = "$OMEGA 0.5 0.7 fix SD SCALE(2.0) 0.8",
+      want = list(
+        values = list(
+          option_record_name$new("omega", "OMEGA"),
+          elem_whitespace(" "),
+          option_nested$new(
+            "omega",
+            values = list(option_pos$new("init", "0.5"))
+          ),
+          elem_whitespace(" "),
+          option_nested$new(
+            "omega",
+            values = list(
+              option_pos$new("init", "0.7"),
+              elem_whitespace(" "),
+              option_flag$new("fixed", "fix"),
+              elem_whitespace(" "),
+              option_flag$new("standard", "SD")
+            )
+          ),
+          elem_whitespace(" "),
+          option_value$new("scale", "SCALE", "(2.0)", sep = ""),
+          elem_whitespace(" "),
+          option_nested$new(
+            "omega",
+            values = list(option_pos$new("init", "0.8"))
+          ),
+          elem_linebreak()
+        )
+      )
+    ),
+    list(
+      input = "$OMEGA SCALE  ( 0.7  ) BLOCK(4) FIX VALUES(0.5,0.01)",
+      want = list(
+        values = list(
+          option_record_name$new("omega", "OMEGA"),
+          elem_whitespace(" "),
+          option_value$new("scale", "SCALE", "( 0.7  )", sep = "  "),
+          elem_whitespace(" "),
+          option_value$new("block", "BLOCK", "(4)", sep = ""),
+          elem_whitespace(" "),
+          option_flag$new("fixed", "FIX"),
+          elem_whitespace(" "),
+          option_nested$new(
+            "omega",
+            values = list(
+              option_flag$new("values", "VALUES"),
+              elem_paren_open(),
+              option_pos$new("diag", "0.5"),
+              elem_comma(),
+              option_pos$new("odiag", "0.01"),
+              elem_paren_close()
+            )
+          ),
+          elem_linebreak()
+        )
+      )
+    ),
+    list(
+      input = "$OMEGA SD SCALE(0.7) FIX BLOCK(4) VALUES(0.5,0.01)",
+      want = list(
+        values = list(
+          option_record_name$new("omega", "OMEGA"),
+          elem_whitespace(" "),
+          option_flag$new("standard", "SD"),
+          elem_whitespace(" "),
+          option_value$new("scale", "SCALE", "(0.7)", sep = ""),
+          elem_whitespace(" "),
+          option_flag$new("fixed", "FIX"),
+          elem_whitespace(" "),
+          option_value$new("block", "BLOCK", "(4)", sep = ""),
+          elem_whitespace(" "),
+          option_nested$new(
+            "omega",
+            values = list(
+              option_flag$new("values", "VALUES"),
+              elem_paren_open(),
+              option_pos$new("diag", "0.5"),
+              elem_comma(),
+              option_pos$new("odiag", "0.01"),
+              elem_paren_close()
+            )
+          ),
+          elem_linebreak()
+        )
+      )
+    ),
+    list(
+      input = c(
+        "$OMEGA BLOCK(4) SCALE",
+        " (0.7) FIX VALUES(0.5,0.01)"
+      ),
+      want = list(
+        values = list(
+          option_record_name$new("omega", "OMEGA"),
+          elem_whitespace(" "),
+          option_value$new("block", "BLOCK", "(4)", sep = ""),
+          elem_whitespace(" "),
+          option_value$new("scale", "SCALE", "(0.7)", sep = "\n "),
+          elem_whitespace(" "),
+          option_flag$new("fixed", "FIX"),
+          elem_whitespace(" "),
+          option_nested$new(
+            "omega",
+            values = list(
+              option_flag$new("values", "VALUES"),
+              elem_paren_open(),
+              option_pos$new("diag", "0.5"),
+              elem_comma(),
+              option_pos$new("odiag", "0.01"),
+              elem_paren_close()
+            )
+          ),
+          elem_linebreak()
+        )
+      )
+    ),
+    list(
+      input = c(
+        "$OMEGA block(2) scale ; (2)",
+        "(3) 4 5 6"
+      ),
+      want = list(
+        values = list(
+          option_record_name$new("omega", "OMEGA"),
+          elem_whitespace(" "),
+          option_value$new("block", "block", "(2)", sep = ""),
+          elem_whitespace(" "),
+          option_value$new("scale", "scale", "(3)", sep = " ; (2)\n"),
+          elem_whitespace(" "),
+          option_nested$new(
+            "omega",
+            values = list(option_pos$new("init", "4"))
+          ),
+          elem_whitespace(" "),
+          option_nested$new(
+            "omega",
+            values = list(option_pos$new("init", "5"))
+          ),
+          elem_whitespace(" "),
+          option_nested$new(
+            "omega",
+            values = list(option_pos$new("init", "6"))
+          ),
+          elem_linebreak()
+        )
+      )
+    ),
+    list(
+      input = "$OMEGA 0.1 scale= scale(3) 0.2",
+      want = list(
+        values = list(
+          option_record_name$new("omega", "OMEGA"),
+          elem_whitespace(" "),
+          option_nested$new(
+            "omega",
+            values = list(option_pos$new("init", "0.1"))
+          ),
+          elem_whitespace(" "),
+          option_pos$new("label", value = "scale="),
+          elem_whitespace(" "),
+          option_value$new("scale", "scale", "(3)", sep = ""),
+          elem_whitespace(" "),
+          option_nested$new(
+            "omega",
+            values = list(option_pos$new("init", "0.2"))
+          ),
+          elem_linebreak()
+        )
+      )
+    ),
+    list(
+      input = "$OMEGA 0.1 scale(3) scale= 0.2",
+      want = list(
+        values = list(
+          option_record_name$new("omega", "OMEGA"),
+          elem_whitespace(" "),
+          option_nested$new(
+            "omega",
+            values = list(option_pos$new("init", "0.1"))
+          ),
+          elem_whitespace(" "),
+          option_value$new("scale", "scale", "(3)", sep = ""),
+          elem_whitespace(" "),
+          option_pos$new("label", value = "scale="),
+          elem_whitespace(" "),
+          option_nested$new(
+            "omega",
+            values = list(option_pos$new("init", "0.2"))
+          ),
+          elem_linebreak()
+        )
+      )
+    ),
+    list(
+      input = c(
+        "$OMEGA SCALE (0.7 ) BLOCK(4) FIX",
+        "0.5",
+        "0.01 0.5",
+        "SCALE(2.5)",
+        "0.02 0.02 SCALE(3.5) 0.003"
+      ),
+      want = list(
+        values = list(
+          option_record_name$new("omega", "OMEGA"),
+          elem_whitespace(" "),
+          option_value$new("scale", "SCALE", "(0.7 )", sep = " "),
+          elem_whitespace(" "),
+          option_value$new("block", "BLOCK", "(4)", sep = ""),
+          elem_whitespace(" "),
+          option_flag$new("fixed", "FIX"),
+          elem_linebreak(),
+          option_nested$new(
+            "omega",
+            values = list(option_pos$new("init", "0.5"))
+          ),
+          elem_linebreak(),
+          option_nested$new(
+            "omega",
+            values = list(option_pos$new("init", "0.01"))
+          ),
+          elem_whitespace(" "),
+          option_nested$new(
+            "omega",
+            values = list(option_pos$new("init", "0.5"))
+          ),
+          elem_linebreak(),
+          option_value$new("scale", "SCALE", "(2.5)", sep = ""),
+          elem_linebreak(),
+          option_nested$new(
+            "omega",
+            values = list(option_pos$new("init", "0.02"))
+          ),
+          elem_whitespace(" "),
+          option_nested$new(
+            "omega",
+            values = list(option_pos$new("init", "0.02"))
+          ),
+          elem_whitespace(" "),
+          option_value$new("scale", "SCALE", "(3.5)", sep = ""),
+          elem_whitespace(" "),
+          option_nested$new(
+            "omega",
+            values = list(option_pos$new("init", "0.003"))
+          ),
+          elem_linebreak()
+        )
+      )
+    ),
+    list(
+      input = c(
+        "$OMEGA BLOCK(2) SCALE(2)",
+        "0.1",
+        "scale= scale(3) 0.02 0.3"
+      ),
+      want = list(
+        values = list(
+          option_record_name$new("omega", "OMEGA"),
+          elem_whitespace(" "),
+          option_value$new("block", "BLOCK", "(2)", sep = ""),
+          elem_whitespace(" "),
+          option_value$new("scale", "SCALE", "(2)", sep = ""),
+          elem_linebreak(),
+          option_nested$new(
+            "omega",
+            values = list(option_pos$new("init", "0.1"))
+          ),
+          elem_linebreak(),
+          option_pos$new("label", value = "scale="),
+          elem_whitespace(" "),
+          option_value$new("scale", "scale", "(3)", sep = ""),
+          elem_whitespace(" "),
+          option_nested$new(
+            "omega",
+            values = list(option_pos$new("init", "0.02"))
+          ),
+          elem_whitespace(" "),
+          option_nested$new(
+            "omega",
+            values = list(option_pos$new("init", "0.3"))
+          ),
+          elem_linebreak()
+        )
+      )
+    ),
+    list(
+      input = c(
+        "$OMEGA BLOCK(2) SCALE(2)",
+        "0.1",
+        "scale(3) scale= 0.02 0.3"
+      ),
+      want = list(
+        values = list(
+          option_record_name$new("omega", "OMEGA"),
+          elem_whitespace(" "),
+          option_value$new("block", "BLOCK", "(2)", sep = ""),
+          elem_whitespace(" "),
+          option_value$new("scale", "SCALE", "(2)", sep = ""),
+          elem_linebreak(),
+          option_nested$new(
+            "omega",
+            values = list(option_pos$new("init", "0.1"))
+          ),
+          elem_linebreak(),
+          option_value$new("scale", "scale", "(3)", sep = ""),
+          elem_whitespace(" "),
+          option_pos$new("label", value = "scale="),
+          elem_whitespace(" "),
+          option_nested$new(
+            "omega",
+            values = list(option_pos$new("init", "0.02"))
+          ),
+          elem_whitespace(" "),
+          option_nested$new(
+            "omega",
+            values = list(option_pos$new("init", "0.3"))
+          ),
+          elem_linebreak()
+        )
+      )
+    ),
+    list(
+      input = c(
+        "$OMEGA BLOCK(2) SCALE(2)",
+        "0.1",
+        "scale(3) FIX alabel= SD 0.02 0.3"
+      ),
+      want = list(
+        values = list(
+          option_record_name$new("omega", "OMEGA"),
+          elem_whitespace(" "),
+          option_value$new("block", "BLOCK", "(2)", sep = ""),
+          elem_whitespace(" "),
+          option_value$new("scale", "SCALE", "(2)", sep = ""),
+          elem_linebreak(),
+          option_nested$new(
+            "omega",
+            values = list(option_pos$new("init", "0.1"))
+          ),
+          elem_linebreak(),
+          option_value$new("scale", "scale", "(3)", sep = ""),
+          elem_whitespace(" "),
+          option_flag$new("fixed", "FIX"),
+          elem_whitespace(" "),
+          option_pos$new("label", value = "alabel="),
+          elem_whitespace(" "),
+          option_flag$new("standard", "SD"),
+          elem_whitespace(" "),
+          option_nested$new(
+            "omega",
+            values = list(option_pos$new("init", "0.02"))
+          ),
+          elem_whitespace(" "),
+          option_nested$new(
+            "omega",
+            values = list(option_pos$new("init", "0.3"))
+          ),
+          elem_linebreak()
+        )
+      )
     )
   )
 
@@ -526,6 +931,37 @@ test_that("parse_omega_record() aborts on invalid vpair", {
     "$OMEGA BLOCK(3) VALUES",
     "$OMEGA BLOCK(3) VALUES(1)",
     "$OMEGA BLOCK(3) VALUES(1,2"
+  )
+
+  for (case in cases) {
+    rec <- record_omega$new("omega", "OMEGA", case)
+    expect_error(rec$parse(), class = "nmrec_parse_error")
+  }
+})
+
+test_that("parse_omega_record() aborts on missing or incomplete scale value", {
+  cases <- list(
+    # no value
+    "$OMEGA SCALE 0.5 0.7",
+    "$OMEGA 0.5 SCALE 0.7",
+    "$OMEGA 0.5 0.7 SCALE",
+    # no closing paren
+    "$OMEGA SCALE(2.0 0.5 0.7",
+    "$OMEGA 0.5 SCALE(2.0 0.7",
+    "$OMEGA 0.5 0.7 SCALE(2.0"
+  )
+
+  for (case in cases) {
+    rec <- record_omega$new("omega", "OMEGA", case)
+    expect_error(rec$parse(), class = "nmrec_parse_error")
+  }
+})
+
+test_that("parse_omega_record() aborts if scale is inside init parens", {
+  cases <- list(
+    # NM-TRAN doesn't support these ("too many nested parentheses").
+    "$OMEGA 1 (fix 2 scale(0.2))",
+    "$OMEGA 1 (2 scale(0.2))"
   )
 
   for (case in cases) {

--- a/tests/testthat/test-record-unsupported.R
+++ b/tests/testthat/test-record-unsupported.R
@@ -41,3 +41,16 @@ test_that("theta: unint cannot be abbreviated beyond 'uni'", {
     )
   }
 })
+
+test_that("parse_omega_record() aborts if scale between init options", {
+  cases <- list(
+    "$OMEGA SCALE(0.1) 0.1 SCALE(2) sd 0.3",
+    "$OMEGA SCALE(0.1) 0.1 SCALE(2) FIX 0.3",
+    "$OMEGA SCALE(0.1) 0.1 sd SCALE(2) fix 0.3"
+  )
+
+  for (case in cases) {
+    rec <- record_omega$new("omega", "OMEGA", case)
+    expect_error(rec$parse(), class = "nmrec_parse_error")
+  }
+})


### PR DESCRIPTION
This PR adds support for the `SCALE` option of `$OMEGA` and `$SIGMA` records introduced in NONMEM 7.6 (gh-43).

This is more involved for two reasons:

 * at the parsing level, it involves some custom logic to support (rather than being covered by the standard option parsing machinery, like the new options added in gh-44).  See message of third commit for more details.

 * it changes the meaning of the `$OMEGA` and `$SIGMA` init values in a way that I think has the potential to surprise `extract_{omega,sigma}` and `set_{omega,sigma}` callers (or more realistically callers of the bbr functions that use these underneath).  We may want to do more here eventually, but for now I've gone with a warning when these functions encounter a `SCALE` option.  See fourth commit and its message.