### PR TITLE
estimation, table: support leading comma in `FORMAT` value

### DIFF
--- a/R/process-options.R
+++ b/R/process-options.R
@@ -65,21 +65,7 @@ parse_option_value <- function(rp, name, name_raw) {
   if (rp$is("paren_open")) {
     sep <- ""
   } else {
-    beg <- rp$idx_e
-    idx_sep <- purrr::detect_index(
-      rp$elems[beg:rp$n_elems],
-      function(x) !elem_is(x, c("whitespace", "equal_sign"))
-    )
-    if (idx_sep < 2) {
-      abort(
-        c(
-          paste("Missing value for", name_raw),
-          rp$format()
-        ),
-        nmrec_error("parse")
-      )
-    }
-    sep <- rp$yank_to(beg + idx_sep - 2)
+    sep <- parse_option_sep(rp, name_raw)
   }
 
   end <- rp$find_closing_paren()
@@ -91,6 +77,26 @@ parse_option_value <- function(rp, name, name_raw) {
   rp$append(
     option_value$new(name, name_raw, value = val, sep = sep)
   )
+}
+
+parse_option_sep <- function(rp, name_raw) {
+  beg <- rp$idx_e
+  idx_sep <- purrr::detect_index(
+    rp$elems[beg:rp$n_elems],
+    function(x) !elem_is(x, c("whitespace", "equal_sign"))
+  )
+  if (idx_sep < 2) {
+    abort(
+      c(
+        paste("Missing value for", name_raw),
+        rp$format()
+      ),
+      nmrec_error("parse")
+    )
+  }
+  sep <- rp$yank_to(beg + idx_sep - 2)
+
+  return(sep)
 }
 
 resolve_option <- function(x, option_names) {

--- a/R/process-options.R
+++ b/R/process-options.R
@@ -80,6 +80,8 @@ parse_option_value <- function(rp, name, name_raw) {
 }
 
 parse_option_sep <- function(rp, name_raw) {
+  rp$assert_remaining()
+
   beg <- rp$idx_e
   idx_sep <- purrr::detect_index(
     rp$elems[beg:rp$n_elems],

--- a/R/process-options.R
+++ b/R/process-options.R
@@ -84,6 +84,29 @@ parse_option_value <- function(rp, name, name_raw) {
   )
 }
 
+parse_format_option_value <- function(rp, name, name_raw) {
+  sep <- parse_option_sep(rp, name_raw)
+  if (rp$is("comma")) {
+    val <- rp$yank()
+    if (inherits(rp$current(), "nmrec_element")) {
+      abort(
+        c(
+          paste("Incomplete specification for", name_raw),
+          rp$format()
+        ),
+        nmrec_error("parse")
+      )
+    }
+    val <- paste0(val, rp$yank())
+  } else {
+    val <- rp$yank(fold_quoted = TRUE)
+  }
+
+  rp$append(
+    option_value$new(name, name_raw, value = val, sep = sep)
+  )
+}
+
 parse_option_sep <- function(rp, name_raw) {
   rp$assert_remaining()
 

--- a/R/process-options.R
+++ b/R/process-options.R
@@ -62,18 +62,14 @@ process_options <- function(rp,
 }
 
 parse_option_value <- function(rp, name, name_raw) {
+  sep <- parse_option_sep(rp, name_raw)
   if (rp$is("paren_open")) {
-    sep <- ""
-  } else {
-    sep <- parse_option_sep(rp, name_raw)
-  }
-
-  end <- rp$find_closing_paren()
-  if (!identical(end, 0L)) {
+    end <- rp$find_closing_paren()
     val <- rp$yank_to(end)
   } else {
     val <- rp$yank(fold_quoted = TRUE)
   }
+
   rp$append(
     option_value$new(name, name_raw, value = val, sep = sep)
   )

--- a/R/record-estimation.R
+++ b/R/record-estimation.R
@@ -1,6 +1,9 @@
 parse_estimation_record <- function() {
   rp <- record_parser$new("estimation", private$name_raw, private$lines)
-  process_options(rp, estimation_option_types, estimation_option_names)
+  process_options(
+    rp, estimation_option_types, estimation_option_names,
+    value_fns = list("format" = parse_format_option_value)
+  )
   rp$assert_done()
 
   return(rp$get_values())

--- a/R/record-table.R
+++ b/R/record-table.R
@@ -14,7 +14,8 @@ parse_table_record <- function() {
   # WRESCHOL/NPDTYPE options, not list1 elements, so don't guard this next call.
   process_options(
     rp, table_option_types, table_option_names,
-    fail_on_unknown = FALSE
+    fail_on_unknown = FALSE,
+    value_fns = list("format" = parse_format_option_value)
   )
 
   saw_list1 <- FALSE
@@ -55,7 +56,8 @@ parse_table_record <- function() {
     rp$gobble()
     process_options(
       rp, table_option_types, table_option_names,
-      fail_on_unknown = FALSE
+      fail_on_unknown = FALSE,
+      value_fns = list("format" = parse_format_option_value)
     )
   }
   rp$assert_done()

--- a/tests/testthat/test-process-options.R
+++ b/tests/testthat/test-process-options.R
@@ -10,12 +10,28 @@ test_that("process_options aborts on missing value", {
   cases <- c(
     "$table num varcalc",
     "$table num varcalc=",
-    "$table num varcalc ; foo"
+    "$table num varcalc ; foo",
+    "$table num format"
   )
   for (case in cases) {
     expect_error(
       record_table$new("table", "table", !!case)$parse(),
       regexp = "missing value", ignore.case = TRUE,
+      class = "nmrec_parse_error"
+    )
+  }
+})
+
+test_that("process_options aborts on incomplete format specification after comma", {
+  cases <- c(
+    "$table num format=,",
+    "$table num format=, ",
+    "$table num format=,;comment"
+  )
+  for (case in cases) {
+    expect_error(
+      record_table$new("table", "table", !!case)$parse(),
+      regexp = "incomplete specification", ignore.case = TRUE,
       class = "nmrec_parse_error"
     )
   }

--- a/tests/testthat/test-process-options.R
+++ b/tests/testthat/test-process-options.R
@@ -1,0 +1,7 @@
+test_that("process_options aborts on unknown value", {
+  expect_error(
+    record_estimation$new("estimation", "est", "$est methood=1")$parse(),
+    regexp = "unknown option", ignore.case = TRUE,
+    class = "nmrec_parse_error"
+  )
+})

--- a/tests/testthat/test-process-options.R
+++ b/tests/testthat/test-process-options.R
@@ -5,3 +5,18 @@ test_that("process_options aborts on unknown value", {
     class = "nmrec_parse_error"
   )
 })
+
+test_that("process_options aborts on missing value", {
+  cases <- c(
+    "$table num varcalc",
+    "$table num varcalc=",
+    "$table num varcalc ; foo"
+  )
+  for (case in cases) {
+    expect_error(
+      record_table$new("table", "table", !!case)$parse(),
+      regexp = "missing value", ignore.case = TRUE,
+      class = "nmrec_parse_error"
+    )
+  }
+})

--- a/tests/testthat/test-record-continuation.R
+++ b/tests/testthat/test-record-continuation.R
@@ -75,6 +75,31 @@ test_that("continuation is parsed correctly", {
     list(
       record_type = "table",
       input = c(
+        "$table ID format=,1PE15.8:160& ;",
+        "       firsto"
+      ),
+      want = list(
+        values = list(
+          option_record_name$new("table", "table"),
+          elem_whitespace(" "),
+          option_pos$new("list1", value = "ID"),
+          elem_whitespace(" "),
+          option_value$new(
+            "format",
+            name_raw = "format", value = ",1PE15.8:160&"
+          ),
+          elem_whitespace(" "),
+          elem_comment(";"),
+          elem_linebreak(),
+          elem_whitespace("       "),
+          option_flag$new("firstonly", name_raw = "firsto", value = TRUE),
+          elem_linebreak()
+        )
+      )
+    ),
+    list(
+      record_type = "table",
+      input = c(
         "$table ID file='foo bar'&",
         "       firsto"
       ),

--- a/tests/testthat/test-record-estimation.R
+++ b/tests/testthat/test-record-estimation.R
@@ -55,6 +55,44 @@ test_that("parse_estimation_record() works", {
           elem_linebreak()
         )
       )
+    ),
+    list(
+      input = "$est meth 1 format =,1PE12.5",
+      want = list(
+        values = list(
+          option_record_name$new("estimation", "est"),
+          elem_whitespace(" "),
+          option_value$new(
+            "method",
+            name_raw = "meth", value = "1", sep = " "
+          ),
+          elem_whitespace(" "),
+          option_value$new(
+            "format",
+            name_raw = "format", value = ",1PE12.5", sep = " ="
+          ),
+          elem_linebreak()
+        )
+      )
+    ),
+    list(
+      input = "$est meth 1 delim=,1PE12.5",
+      want = list(
+        values = list(
+          option_record_name$new("estimation", "est"),
+          elem_whitespace(" "),
+          option_value$new(
+            "method",
+            name_raw = "meth", value = "1", sep = " "
+          ),
+          elem_whitespace(" "),
+          option_value$new(
+            "format",
+            name_raw = "delim", value = ",1PE12.5", sep = "="
+          ),
+          elem_linebreak()
+        )
+      )
     )
   )
 

--- a/tests/testthat/test-record-table.R
+++ b/tests/testthat/test-record-table.R
@@ -118,6 +118,19 @@ test_that("parse_table_record() works", {
           elem_linebreak()
         )
       )
+    ),
+    list(
+      input = "$table id file'foo'",
+      want = list(
+        values = list(
+          option_record_name$new("table", "table"),
+          elem_whitespace(" "),
+          option_pos$new("list1", value = "id"),
+          elem_whitespace(" "),
+          option_value$new("file", name_raw = "file", sep = "", value = "'foo'"),
+          elem_linebreak()
+        )
+      )
     )
   )
 

--- a/tests/testthat/test-record-table.R
+++ b/tests/testthat/test-record-table.R
@@ -131,6 +131,62 @@ test_that("parse_table_record() works", {
           elem_linebreak()
         )
       )
+    ),
+    list(
+      input = "$table num format=,1PE11.4",
+      want = list(
+        values = list(
+          option_record_name$new("table", "table"),
+          elem_whitespace(" "),
+          option_pos$new("list1", value = "num"),
+          elem_whitespace(" "),
+          option_value$new("format", name_raw = "format", value = ",1PE11.4"),
+          elem_linebreak()
+        )
+      )
+    ),
+    list(
+      input = "$table num format,1PE11.4 file=a",
+      want = list(
+        values = list(
+          option_record_name$new("table", "table"),
+          elem_whitespace(" "),
+          option_pos$new("list1", value = "num"),
+          elem_whitespace(" "),
+          option_value$new("format", name_raw = "format", sep = "", value = ",1PE11.4"),
+          elem_whitespace(" "),
+          option_value$new("file", name_raw = "file", value = "a"),
+          elem_linebreak()
+        )
+      )
+    ),
+    list(
+      input = "$table num format ,1PE11.4 file=a",
+      want = list(
+        values = list(
+          option_record_name$new("table", "table"),
+          elem_whitespace(" "),
+          option_pos$new("list1", value = "num"),
+          elem_whitespace(" "),
+          option_value$new("format", name_raw = "format", sep = " ", value = ",1PE11.4"),
+          elem_whitespace(" "),
+          option_value$new("file", name_raw = "file", value = "a"),
+          elem_linebreak()
+        )
+      )
+    ),
+    list(
+      input = "$table num format=,1PE15.8:160",
+      want = list(
+        values = list(
+          option_record_name$new("table", "table"),
+          elem_whitespace(" "),
+          option_pos$new("list1", value = "num"),
+          elem_whitespace(" "),
+          option_value$new("format", name_raw = "format", sep = "=", value = ",1PE15.8:160"),
+          elem_linebreak()
+        )
+      )
     )
   )
 


### PR DESCRIPTION
The `FORMAT` value may contain a leading comma.  From NONMEM 7.6's `help/format.ctl`:

```
 FORMAT=s1PE12.5

      s defines the delimiter [,|s(pace)|t(ab)] followed by a   Fortran
      format specification.  The FORMAT option is case-insensitive.
```

For an unquoted value, nmrec treats `,` as a delimiter, so a value like `,1PE12.5` leads to a parse error.  See gh-42.

This series resolves the issue by defining a tailored parser for `FORMAT` and extending `process_options` to support specifying a tailored parser for particular options.
