### PR TITLE
Prepare 0.5.1 release

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: nmrec
 Title: Read, Parse, and Modify NONMEM Control Records
-Version: 0.5.0
+Version: 0.5.1
 Authors@R:
     c(person(given = "Kyle",
              family = "Meyer",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# nmrec 0.5.1
+
+## Bug fixes
+
+* The `$TABLE` parser did not recognize the `INTERPTYPE` option (added
+  in NONMEM 7.5.1).  (#49)
+
+
 # nmrec 0.5.0
 
 ## New features


### PR DESCRIPTION
The only changes in functionality are from gh-49.  All other changes are CI updates and automatic formatting.

changeset: [0.5.0...release/0.5.1](https://github.com/metrumresearchgroup/nmrec/compare/0.5.0...release/0.5.1)

<details>
<summary>scores</summary>


```
$ git rev-parse HEAD^{tree}
675237478045008d9ceda6c46ead2ea7c52c8d46
```

```json
{
  "testing": {
    "check": 1,
    "coverage": 0.9875
  },
  "documentation": {
    "has_vignettes": 1,
    "has_website": 1,
    "has_news": 1
  },
  "maintenance": {
    "has_maintainer": 1,
    "news_current": 1
  },
  "transparency": {
    "has_source_control": 1,
    "has_bug_reports_url": 1
  }
}
```

</details>