### PR TITLE
estimation: fix noslow/slow parsing

### DIFF
--- a/R/record-estimation.R
+++ b/R/record-estimation.R
@@ -4,11 +4,29 @@ parse_estimation_record <- function() {
     rp,
     estimation_option_types,
     estimation_option_names,
-    value_fns = list("format" = parse_format_option_value)
+    value_fns = list(
+      "format" = parse_format_option_value,
+      "slow" = parse_slow_option_value
+    )
   )
   rp$assert_done()
 
   return(rp$get_values())
+}
+
+parse_slow_option_value <- function(rp, name, name_raw) {
+  idx <- rp$find_next(function(x) !elem_is(x, c("whitespace", "equal_sign")))
+
+  # Note: 3 isn't a documented value, but NM-TRAN doesn't error if it's used.
+  valid <- c("1", "2", "3")
+  if (identical(idx, 0L) || !rp$elems[[idx]] %in% valid) {
+    rp$append(option_flag$new(name, name_raw))
+    return(NULL)
+  }
+
+  sep <- parse_option_sep(rp, name_raw)
+  val <- rp$yank()
+  rp$append(option_value$new(name, name_raw, value = val, sep = sep))
 }
 
 #' @rdname record

--- a/R/record-estimation.R
+++ b/R/record-estimation.R
@@ -103,7 +103,7 @@ estimation_option_types <- list(
   "norepeat2" = option_type_flag,
   "nosigmaboundtest" = option_type_flag,
   "nosub" = option_type_value,
-  "noslow" = option_type_value,
+  "noslow" = option_type_flag,
   "nosort" = option_type_flag,
   "nothetaboundtest" = option_type_flag,
   "notitle" = option_type_value,

--- a/tests/testthat/test-record-estimation.R
+++ b/tests/testthat/test-record-estimation.R
@@ -112,6 +112,128 @@ test_that("parse_estimation_record() works", {
         )
       )
     ),
+    # SLOW option may be specified with a value...
+    list(
+      input = "$est meth 1 SLOW=1",
+      want = list(
+        values = list(
+          option_record_name$new("estimation", "est"),
+          elem_whitespace(" "),
+          option_value$new(
+            "method",
+            name_raw = "meth",
+            value = "1",
+            sep = " "
+          ),
+          elem_whitespace(" "),
+          option_value$new(
+            "slow",
+            name_raw = "SLOW",
+            value = "1",
+            sep = "="
+          ),
+          elem_linebreak()
+        )
+      )
+    ),
+    list(
+      input = "$est meth 1 slow 2",
+      want = list(
+        values = list(
+          option_record_name$new("estimation", "est"),
+          elem_whitespace(" "),
+          option_value$new(
+            "method",
+            name_raw = "meth",
+            value = "1",
+            sep = " "
+          ),
+          elem_whitespace(" "),
+          option_value$new(
+            "slow",
+            name_raw = "slow",
+            value = "2",
+            sep = " "
+          ),
+          elem_linebreak()
+        )
+      )
+    ),
+    # ... or SLOW can be specified without a value.
+    list(
+      input = "$est meth 1 SLOW ctype=3",
+      want = list(
+        values = list(
+          option_record_name$new("estimation", "est"),
+          elem_whitespace(" "),
+          option_value$new(
+            "method",
+            name_raw = "meth",
+            value = "1",
+            sep = " "
+          ),
+          elem_whitespace(" "),
+          option_flag$new("slow", name_raw = "SLOW"),
+          elem_whitespace(" "),
+          option_value$new(
+            "ctype",
+            name_raw = "ctype",
+            value = "3",
+            sep = "="
+          ),
+          elem_linebreak()
+        )
+      )
+    ),
+    list(
+      input = c(
+        "$est meth 1 SLOW",
+        "  ctype=3"
+      ),
+      want = list(
+        values = list(
+          option_record_name$new("estimation", "est"),
+          elem_whitespace(" "),
+          option_value$new(
+            "method",
+            name_raw = "meth",
+            value = "1",
+            sep = " "
+          ),
+          elem_whitespace(" "),
+          option_flag$new("slow", name_raw = "SLOW"),
+          elem_linebreak(),
+          elem_whitespace("  "),
+          option_value$new(
+            "ctype",
+            name_raw = "ctype",
+            value = "3",
+            sep = "="
+          ),
+          elem_linebreak()
+        )
+      )
+    ),
+    list(
+      input = "$est meth 1 SLOW ; comment",
+      want = list(
+        values = list(
+          option_record_name$new("estimation", "est"),
+          elem_whitespace(" "),
+          option_value$new(
+            "method",
+            name_raw = "meth",
+            value = "1",
+            sep = " "
+          ),
+          elem_whitespace(" "),
+          option_flag$new("slow", name_raw = "SLOW"),
+          elem_whitespace(" "),
+          elem_comment("; comment"),
+          elem_linebreak()
+        )
+      )
+    ),
     list(
       input = "$est meth 1 NOSLOW",
       want = list(

--- a/tests/testthat/test-record-estimation.R
+++ b/tests/testthat/test-record-estimation.R
@@ -111,6 +111,24 @@ test_that("parse_estimation_record() works", {
           elem_linebreak()
         )
       )
+    ),
+    list(
+      input = "$est meth 1 NOSLOW",
+      want = list(
+        values = list(
+          option_record_name$new("estimation", "est"),
+          elem_whitespace(" "),
+          option_value$new(
+            "method",
+            name_raw = "meth",
+            value = "1",
+            sep = " "
+          ),
+          elem_whitespace(" "),
+          option_flag$new("noslow", name_raw = "NOSLOW"),
+          elem_linebreak()
+        )
+      )
     )
   )
 


### PR DESCRIPTION

 * correct type of `NOSLOW`
 * add tailored parser to handle no-value `SLOW` form

Fixes #51 